### PR TITLE
feat: Added support for Consul wan address

### DIFF
--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -285,6 +285,7 @@ class Ha(object):
         with self._member_state_lock:
             data: Dict[str, Any] = {
                 'conn_url': self.state_handler.connection_string,
+                'addresses': self.state_handler.multi_connection,
                 'api_url': self.patroni.api.connection_string,
                 'state': self.state_handler.state,
                 'role': self.state_handler.role,

--- a/patroni/postgresql/config.py
+++ b/patroni/postgresql/config.py
@@ -942,6 +942,7 @@ class ConfigHandler(object):
             if self._config.get('use_unix_socket_repl') else tcp_local_address
 
         self._postgresql.connection_string = uri('postgres', netloc, self._postgresql.database)
+        self._postgresql.multi_connection = self._config.get('connect_address_wan')
         self._postgresql.set_connection_kwargs(self.local_connect_kwargs)
 
     def _get_pg_settings(


### PR DESCRIPTION
Added required variables to enable a secondary IP Address for Standby-Leader replication purposes on Multi-Ha cluster setup, resolving a different IP address when querying the Consul DNS service rather than resolving the same IP address from the Main DC cluster. We are achieving the target using the available Consul tagged_addresses feature for WAN and LAN setup.